### PR TITLE
Загрузка gwf файлов

### DIFF
--- a/client/js/Ui/KeyboardHandler.js
+++ b/client/js/Ui/KeyboardHandler.js
@@ -83,3 +83,12 @@ SCWeb.ui.KeyboardHandler = {
         }
     }
 }
+
+/**
+ * Turn off hot key in browsers
+ */
+document.onkeydown = function(event) {
+    if ((event.which == KeyCode.A) && event.ctrlKey) {
+        return false;
+    }
+};

--- a/client/templates/base.html
+++ b/client/templates/base.html
@@ -110,7 +110,7 @@
                 </div>
             </div>
         </div>
-        <div id="window-header-tools" class="pull-right" style="padding-right: 15px;">
+        <div id="window-header-tools" class="pull-right" style="padding-right: 35px;">
             <div class="btn-group">
                 <button type="button" class="btn btn-success ">
                     <span class="glyphicon glyphicon-font"></span>

--- a/components/scg/build.json
+++ b/components/scg/build.json
@@ -24,6 +24,7 @@
         "src/listener/scg-mode-edge.js",
         "src/listener/scg-mode-link.js",
         "src/listener/scg-mode-select.js",
+        "src/command/append-object.js",
         "src/command/command-manager.js",
         "src/command/create-node.js",
         "src/command/create-edge.js",

--- a/components/scg/src/command/append-object.js
+++ b/components/scg/src/command/append-object.js
@@ -1,0 +1,27 @@
+SCgCommandAppendObject = function (object, scene) {
+    this.object = object;
+    this.scene = scene;
+};
+
+SCgCommandAppendObject.prototype = {
+
+    constructor: SCgCommandAppendObject,
+
+
+    undo: function() {
+        if (this.object) {
+            var idx = this.scene.selected_objects.indexOf(this.object);
+            this.scene.selected_objects.splice(idx, 1);
+            this.object._setSelected(false);
+            this.scene.edit.onSelectionChanged();
+            this.scene.line_points = [];
+        }
+        this.scene.removeObject(this.object);
+    },
+
+    execute: function() {
+        this.scene.appendObject(this.object);
+        this.object.update();
+    }
+
+};

--- a/components/scg/src/gwf-file-loader.js
+++ b/components/scg/src/gwf-file-loader.js
@@ -25,8 +25,8 @@ GwfFileLoader = {
                 GwfObjectInfoReader.printErrors();
 
         }
-        reader.readAsText(args["file"], "CP1251");
-//        reader.readAsText(args["file"]);
+//        reader.readAsText(args["file"], "CP1251");
+        reader.readAsText(args["file"]);
         return true;
     }
 }

--- a/components/scg/src/gwf-object-info-reader.js
+++ b/components/scg/src/gwf-object-info-reader.js
@@ -16,7 +16,7 @@ GwfObjectInfoReader = {
         "node/const/predmet": sc_type_node | sc_type_const | sc_type_node_abstract,
 
         "node/var/general_node": sc_type_node | sc_type_var,
-        "node/var/asymmetry": sc_type_node | sc_type_var | sc_type_node_tuple,
+        "node/var/symmetry": sc_type_node | sc_type_var | sc_type_node_tuple,
         "node/var/nopredmet": sc_type_node | sc_type_var | sc_type_node_struct,
         "node/var/attribute": sc_type_node | sc_type_var | sc_type_node_role,
         "node/var/relation": sc_type_node | sc_type_var | sc_type_node_norole,
@@ -47,7 +47,7 @@ GwfObjectInfoReader = {
     },
 
     read: function (strs) {
-
+        this.objects_info = {};
         var xml_doc = (new DOMParser()).parseFromString(strs, "text/xml");
 
         var root = xml_doc.documentElement;
@@ -135,13 +135,15 @@ GwfObjectInfoReader = {
     },
 
     parseNode: function (node) {
-
-        var parsed_node = new GwfObjectNode(null);
-
-
+        var content = node.getElementsByTagName("content");
+        var parsed_node;
+        if (content[0].textContent == ""){
+            parsed_node = new GwfObjectNode(null);
+        } else {
+            parsed_node = new GwfObjectLink(null);
+        }
         if (parsed_node.parseObject({gwf_object: node, reader: this}) == false)
             return false;
-
         this.objects_info[parsed_node.id] = parsed_node;
 
     },

--- a/components/scg/src/listener/scg-mode-select.js
+++ b/components/scg/src/listener/scg-mode-select.js
@@ -20,9 +20,7 @@ SCgSelectListener.prototype = {
         this.scene.mouse_pos.y = y;
         if (this.scene.focused_object) {
             this.scene.selected_objects.forEach(function (object) {
-                if (object.sc_type & (sc_type_node | sc_type_link)) {
-                    object.setPosition(object.position.clone().add(offset));
-                }
+                object.setPosition(object.position.clone().add(offset));
             });
             this.scene.updateObjectsVisual();
             return true;
@@ -48,7 +46,6 @@ SCgSelectListener.prototype = {
         this.position = this.scene.focused_object.position.clone();
         if (obj instanceof SCg.ModelContour || obj instanceof SCg.ModelBus) {
             obj.previousPoint = new SCg.Vector2(this.scene.mouse_pos.x, this.scene.mouse_pos.y);
-            return true;
         }
         if (d3.event.ctrlKey){
             this.selectObject(obj);
@@ -67,9 +64,7 @@ SCgSelectListener.prototype = {
         if (!this.position.equals(this.scene.focused_object.position) && this.offsetObject == obj){
             var commands = [];
             this.scene.selected_objects.forEach(function (object) {
-                if (object.sc_type & (sc_type_node | sc_type_link)) {
-                    commands.push(new SCgCommandMoveObject(object, offset));
-                }
+                commands.push(new SCgCommandMoveObject(object, offset));
             });
             this.scene.commandManager.execute(new SCgWrapperCommand(commands), true);
             this.offsetObject = null;

--- a/components/scg/src/scg-alphabet.js
+++ b/components/scg/src/scg-alphabet.js
@@ -273,12 +273,20 @@ var SCgAlphabet = {
                         .attr('d', position_path);
                 }
             } else if (edge.sc_type & (sc_type_arc_common | sc_type_edge_common)) {
-                
-                var p = d3_group.append('svg:path')
-                    .classed('SCgEdgeCommonBack', true)
-                    .classed('SCgEdgeEndArrowCommon', edge.sc_type & sc_type_arc_common)
-                    .style("marker-end", "url(#end-arrow-common_" + containerId + ")")
-                    .attr('d', position_path);
+
+                if (edge.sc_type & sc_type_edge_common){
+                    d3_group.append('svg:path')
+                        .classed('SCgEdgeCommonBack', true)
+                        .attr('d', position_path);
+                }
+
+                if (edge.sc_type & sc_type_arc_common) {
+                    d3_group.append('svg:path')
+                        .classed('SCgEdgeCommonBack', true)
+                        .classed('SCgEdgeEndArrowCommon', edge.sc_type & sc_type_arc_common)
+                        .style("marker-end", "url(#end-arrow-common_" + containerId + ")")
+                        .attr('d', position_path);
+                }
                 
                 d3_group.append('svg:path')
                     .classed('SCgEdgeCommonForeground', true)
@@ -314,6 +322,10 @@ var SCgAlphabet = {
         // now we need to draw fuz markers (for now it not supported)
         if (edge.sc_type & sc_type_arc_fuz) {
             d3_group.selectAll('path').attr('stroke', '#f00');
+            d3_group.append('svg:path')
+                .classed('SCgEdgeFuzDash', true)
+                .attr('d', position_path)
+                .attr('stroke', '#f00');
         }
         
     },

--- a/components/scg/src/scg-model-objects.js
+++ b/components/scg/src/scg-model-objects.js
@@ -369,6 +369,15 @@ SCg.ModelEdge = function(options) {
 
 SCg.ModelEdge.prototype = Object.create( SCg.ModelObject.prototype );
 
+SCg.ModelEdge.prototype.setPosition = function(offset) {
+    var dp = offset.clone().sub(this.position);
+    for (var i = 0; i < this.points.length; i++) {
+        this.points[i].x += dp.x;
+        this.points[i].y += dp.y;
+    }
+    SCg.ModelObject.prototype.setPosition.call(this, offset);
+};
+
 /**
  * Destroy object
  */
@@ -511,8 +520,13 @@ SCg.ModelEdge.prototype.getConnectionPos = function(from, dotPos) {
         else
             beg_pos = this.source_pos;
     } else {
-        beg_pos = new SCg.Vector3(this.points[sector - 1].x, this.points[sector - 1].y, 0);
-        end_pos = new SCg.Vector3(this.points[sector].x, this.points[sector].y, 0);
+        if (this.points.length > sector){
+            beg_pos = new SCg.Vector3(this.points[sector - 1].x, this.points[sector - 1].y, 0);
+            end_pos = new SCg.Vector3(this.points[sector].x, this.points[sector].y, 0);
+        } else {
+            beg_pos = new SCg.Vector3(this.source.x, this.source.y, 0);
+            end_pos = new SCg.Vector3(this.target.x, this.target.y, 0);
+        }
     }
         
     var l_pt = new SCg.Vector3(0, 0, 0);
@@ -609,8 +623,10 @@ SCg.ModelContour.prototype.setPosition = function(pos) {
     var dp = pos.clone().sub(this.position);
     
     for (var i = 0; i < this.childs.length; i++) {
-        var newPos = this.childs[i].position.clone().add(dp);
-        this.childs[i].setPosition(newPos);
+        if (!this.childs[i].is_selected){
+            var newPos = this.childs[i].position.clone().add(dp);
+            this.childs[i].setPosition(newPos);
+        }
     }
 
     for (var i = 0; i < this.points.length; i++) {
@@ -729,6 +745,15 @@ SCg.ModelBus = function(options) {
 
 SCg.ModelBus.prototype = Object.create( SCg.ModelObject.prototype );
 
+SCg.ModelBus.prototype.setPosition = function(offset) {
+    var dp = offset.clone().sub(this.position);
+    for (var i = 0; i < this.points.length; i++) {
+        this.points[i].x += dp.x;
+        this.points[i].y += dp.y;
+    }
+    SCg.ModelObject.prototype.setPosition.call(this, offset);
+};
+
 SCg.ModelBus.prototype.update = function() {
     
     if (!this.source_pos)
@@ -831,3 +856,5 @@ SCg.ModelBus.prototype.destroy = function() {
     if (this.source)
         this.source.removeBus();
 };
+
+

--- a/components/scg/src/scg-object-builder.js
+++ b/components/scg/src/scg-object-builder.js
@@ -1,7 +1,7 @@
 ScgObjectBuilder = {
     scg_objects: {},
     gwf_objects: {},
-
+    commandList: [],
     scene: null,
 
     buildObjects: function (gwf_objects) {
@@ -14,8 +14,10 @@ ScgObjectBuilder = {
                     builder: this
                 });
                 this.scg_objects[gwf_object.attributes.id] = scg_object;
+                this.commandList.push(new SCgCommandAppendObject(scg_object, this.scene));
             }
         }
+        this.scene.commandManager.execute(new SCgWrapperCommand(this.commandList), true);
         this.emptyObjects();
     },
 
@@ -26,7 +28,8 @@ ScgObjectBuilder = {
             this.scg_objects[gwf_object_id] = gwf_object.buildObject({
                 scene: this.scene,
                 builder: this
-            })
+            });
+            this.commandList.push(new SCgCommandAppendObject(this.scg_objects[gwf_object_id], this.scene));
         }
         return this.scg_objects[gwf_object_id];
     },

--- a/components/scg/src/scg-object-builder.js
+++ b/components/scg/src/scg-object-builder.js
@@ -6,7 +6,6 @@ ScgObjectBuilder = {
 
     buildObjects: function (gwf_objects) {
         this.gwf_objects = gwf_objects;
-
         for (var gwf_object_id  in gwf_objects) {
             var gwf_object = gwf_objects[gwf_object_id];
             if (gwf_object.attributes.id in this.scg_objects == false) {
@@ -17,6 +16,7 @@ ScgObjectBuilder = {
                 this.scg_objects[gwf_object.attributes.id] = scg_object;
             }
         }
+        this.emptyObjects();
     },
 
     getOrCreate: function (gwf_object_id) {
@@ -29,5 +29,10 @@ ScgObjectBuilder = {
             })
         }
         return this.scg_objects[gwf_object_id];
+    },
+
+    emptyObjects: function () {
+        this.gwf_objects = {};
+        this.scg_objects = {};
     }
 }

--- a/components/scg/src/scg-render.js
+++ b/components/scg/src/scg-render.js
@@ -70,9 +70,9 @@ SCg.Render.prototype = {
                 d3.event.stopPropagation();
             });
         this.d3_edges = this.d3_container.append('svg:g').selectAll('path');
+        this.d3_buses = this.d3_container.append('svg:g').selectAll('path');
         this.d3_nodes = this.d3_container.append('svg:g').selectAll('g');
         this.d3_links = this.d3_container.append('svg:g').selectAll('g');
-        this.d3_buses = this.d3_container.append('svg:g').selectAll('path');
         this.d3_dragline = this.d3_container.append('svg:g');
         this.d3_line_points = this.d3_container.append('svg:g');
         

--- a/components/scg/src/scg-scene.js
+++ b/components/scg/src/scg-scene.js
@@ -34,6 +34,7 @@ var KeyCode = {
     KeyEqualFirefox: 61,
     KeyEqual: 187,
     KeyPlusNum: 107,
+    A: 65,
     C: 67,
     I: 73,
     T: 84,
@@ -283,7 +284,25 @@ SCg.Scene.prototype = {
             
         return null;
     },
-    
+
+    /**
+     * Selection all object
+     */
+    selectAll: function () {
+        var self = this;
+        var allObjects = [this.nodes, this.edges, this.buses, this.contours, this.links];
+        allObjects.forEach(function (setObjects) {
+            setObjects.forEach(function (obj) {
+                if (!obj.is_selected) {
+                    self.selected_objects.push(obj);
+                    obj._setSelected(true);
+                }
+            });
+        });
+        this.updateObjectsVisual();
+        this._fireSelectionChanged();
+    },
+
     /**
      * Append selection to object
      */
@@ -403,6 +422,8 @@ SCg.Scene.prototype = {
             } else if (event.ctrlKey && (event.which == KeyCode.Z)) {
                 this.commandManager.undo();
                 this.updateRender();
+            } else if ((event.which == KeyCode.A) && event.ctrlKey) {
+                this.selectAll();
             } else if (event.which == KeyCode.Key1) {
                 this.edit.toolSelect().click()
             } else if (event.which == KeyCode.Key2) {

--- a/components/scg/src/scg.js
+++ b/components/scg/src/scg.js
@@ -538,7 +538,7 @@ SCg.Editor.prototype = {
         this.toolOpen().click(function() {
             var document = $(this)[0].ownerDocument;
             var open_dialog = document.getElementById("scg-tool-open-dialog");
-
+            self.scene.clearSelection();
             open_dialog.onchange = function(){
                 return GwfFileLoader.load({
                     file: open_dialog.files[0],

--- a/components/scg/static/components/css/scg.css
+++ b/components/scg/static/components/css/scg.css
@@ -119,6 +119,12 @@
     stroke-width: 10px;
 }
 
+/* TODO */
+.SCgEdgeFuzDash {
+    stroke-dasharray: 0, 20, 2, 6;
+    stroke-width: 10px;
+}
+
 /* --------- */
 .SCgEdgePermDash {
     stroke-dasharray: 4, 10;


### PR DESCRIPTION
**Исправления**
Отключена глобально горячая клавиша Ctrl+A
Добавлено выделение всех элементов в SCg-редакторе(клавиша Ctrl+A)
Исправлены проблемы с загрузкой gwf фалов(повторная загрузка, загрузка шины, загрузка ссылок, выделение элементов при загрузке)
Слой шин был перенесен на слой узлов(т.к шины всегда были над ссылками, которые могут закрывать все объекты шины, кроме самой шины)
Добавлено перемещение шин и ломаных ребер, убрано двойное перемещение элементов контура
Убрано отображение стрелки в ненаправленных ребрах